### PR TITLE
ajout archivées et personnelles

### DIFF
--- a/exploitation_auto_pix_orga.py
+++ b/exploitation_auto_pix_orga.py
@@ -14,6 +14,11 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+#    Modifié par Marius Monnier (Février 2022):
+#    * ajout des filtres: campagnes archivées, campagnes personnelles
+#    * ajout d'une fonction utilitaire pour tester le "(o/n)"
+#    * correction d'un bug si l'utilisateur ne peut pas certifier.
+
 import io
 import os
 from datetime import datetime
@@ -125,13 +130,22 @@ def choix_centre(token_certif):
 
 
 
-def liste_campagnes(token_orga,organisation_id,nb_campagnes_max=100):
+def liste_campagnes(token_orga,organisation_id,nb_campagnes_max=100,only_me=False, also_archived=False):
     #Pour Pix Orga
     headers={'Authorization': 'Bearer '+ token_orga}
     nb_campagnes_max = str(nb_campagnes_max)
-    print("Récupération des résultats des dernières campagnes non archivées (max = "+nb_campagnes_max+" campagnes)")
-    r = requests.get("https://orga.pix.fr/api/organizations/"+organisation_id+"/campaigns?page[number]=1&page[size]="+nb_campagnes_max, headers=headers)
-    campagnes=r.json()['data']
+    print("Récupération des résultats des dernières campagnes (max = "+nb_campagnes_max+" campagnes, archivées="+str(also_archived)+", personnelles="+str(only_me)+")")
+    filters = '' # De base aucun filtre
+
+    if only_me: # Si on veut seulement voir ses campagnes
+        filters='&filter[isOwnedByMe]=true'
+
+    r_actives = requests.get("https://orga.pix.fr/api/organizations/"+organisation_id+"/campaigns?page[number]=1"+filters+"&page[size]="+nb_campagnes_max, headers=headers)
+    campagnes = r_actives.json()['data']
+    if also_archived: # Si on veut voir aussi les campagnes archivées
+        filters += '&filter[status]=archived'
+        r_archived = requests.get("https://orga.pix.fr/api/organizations/"+organisation_id+"/campaigns?page[number]=1"+filters+"&page[size]="+nb_campagnes_max, headers=headers)
+        campagnes += r_archived.json()['data']
     return campagnes
 
 def liste_sessions(token_certif,centre_id,nb_sessions_max=200):
@@ -456,7 +470,7 @@ def reinitialisation_mdp_classe(classe,token_orga,organisation_id,sortie_html=Tr
     
     return eleves_a_reinit
 
-def traitement_synthese(resultats_globaux):
+def traitement_synthese(resultats_globaux,eleves):
     print("!!! Traitement de la synthèse                   !!!")
     
     # Avant avant avant dernière colonne Certifiable O/N
@@ -743,8 +757,10 @@ def date_mise_a_jour_github(nom_depot='Resultats-Campagne-PIX-orga'):
 
 date_mise_a_jour_github('Resultats-Campagne-PIX-orga')
 
+def is_oui(reponse: str):
+    return reponse.upper() in ['O', 'OUI', 'Y', 'YES']
     
-if __name__ == "__main__":
+def main():
     sortie_html = False
     sortie_pdf = True
     sortie_csv = False
@@ -755,28 +771,33 @@ if __name__ == "__main__":
     token_orga,user_id_orga=identification_orga(username,password)
     organisation_id=choix_organisation(token_orga,user_id_orga)
 
-    token_certif,user_id_certif=identification_certif(username,password)    
-    centre_id=choix_centre(token_certif)
+    traitement_certif_OK = is_oui(input("??? Voulez-vous suivre les certifications (o/n) ? Par défaut Non. "))
+    if traitement_certif_OK: # Si on a pas de compte certif, le script plante
+        token_certif,user_id_certif=identification_certif(username,password)    
+        centre_id=choix_centre(token_certif)
 
     del username
     del password
-
-    traitement_certif_OK = input("??? Voulez-vous suivre les certifications (o/n) ? Par défaut Non. ")
-    
-    sortie_campagne_OK   = input("??? Voulez-vous les fichiers des campagnes (o/n) ? Par défaut Non. ")
+        
+    sortie_campagne_OK   = is_oui(input("??? Voulez-vous les fichiers des campagnes (o/n) ? Par défaut Non. "))
+    archived_campagne_OK = is_oui(input("??? Voulez vous les campagnes archivées (o/n) ? Par défaut Non. "))
+    only_mine_OK = is_oui(input("??? Voulez vous seulement vos campagnes (o/n) ? Par défaut Non. "))
     
     eleves_detail =liste_eleves_detail(token_orga,organisation_id)
     eleves = liste_eleves(eleves_detail)
 
     resultats_globaux=pd.DataFrame(columns=['Nom du Participant','Prénom du Participant','Classe','Connecté'])
 
-    campagnes=liste_campagnes(token_orga,organisation_id)    
+    if only_mine_OK or archived_campagne_OK:
+        campagnes=liste_campagnes(token_orga,organisation_id, only_me=only_mine_OK, also_archived=archived_campagne_OK)
+    else:
+        campagnes=liste_campagnes(token_orga,organisation_id)
     
     for campagne in campagnes :
         nom_campagne,resultats=lecture_campagne(token_orga,campagne)
         if nom_campagne!="":
             resultats,resultats_globaux = traitement_campagne(nom_campagne,resultats,resultats_globaux)
-            if sortie_campagne_OK in ['Oui','OUI','oui','O','o']:
+            if sortie_campagne_OK:
                 sortie_par_classe(nom_campagne,resultats,eleves,sortie_html,sortie_pdf,sortie_csv)
 
     resultats = liste_identifiants(eleves_detail)
@@ -785,7 +806,7 @@ if __name__ == "__main__":
           
 
 
-    if traitement_certif_OK in ['Oui','OUI','oui','O','o']:        
+    if traitement_certif_OK:        
     
         resultats_certifications = pd.DataFrame(columns=['Nom du Participant','Prénom du Participant','Classe'])
         
@@ -801,6 +822,8 @@ if __name__ == "__main__":
         
 
 
-    resultats_globaux = traitement_synthese(resultats_globaux)
+    resultats_globaux = traitement_synthese(resultats_globaux,eleves)
     sortie_par_classe('Synthèse résultats Pix',resultats_globaux,eleves,sortie_html,sortie_pdf,True,'paysage')
 
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
J'ai utilisé l'outil pour pouvoir récupérer les données de mes étudiants dans pixOrga.

Malheureusement, cela extrayait toutes les données de toutes les campagnes **non archivées**.
Comme j'avais besoin d'en récupérer des archivées et de seulement les miennes j'ai rajouté la possibilité via deux flags, désactivés par défaut pour avoir le comportement initial.

Merci pour le super travail fait dans ce logiciel !